### PR TITLE
avoid display search query string for components

### DIFF
--- a/rm/search.go
+++ b/rm/search.go
@@ -144,7 +144,6 @@ func search(rm RM, endpoint string, queryBuilder nexus.SearchQueryBuilder, respo
 
 // SearchComponents allows searching the indicated RM instance for specific components
 func SearchComponents(rm RM, query nexus.SearchQueryBuilder) ([]RepositoryItem, error) {
-	fmt.Println("query", query.Build())
 	items := make([]RepositoryItem, 0)
 
 	err := search(rm, restSearchComponents, query, func(body []byte) (string, error) {


### PR DESCRIPTION
Same behavior than function SearchAssets, no display of query string.

To avoid displaying a message with the query string when using SearchComponents function, this line must be deleted.

Regards
