### PR TITLE
add policyViolationId to policyReportViolation struct

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/gonexus.iml
+++ b/.idea/gonexus.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/gonexus.iml" filepath="$PROJECT_DIR$/.idea/gonexus.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sonatype-nexus-community/gonexus
+module github.com/Tom-B-gw/gonexus
 
 go 1.12

--- a/iq/policyWaivers.go
+++ b/iq/policyWaivers.go
@@ -1,0 +1,85 @@
+package nexusiq
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	policyWaivers = "/api/v2/policyWaivers/%s/%s"
+)
+
+// OwnerType type defines the organizational scope of the waiver
+type OwnerType string
+
+// Provides guide rails for the owner types
+const (
+	OwnerApplication         OwnerType = "application"
+	OwnerOrganization        OwnerType = "organization"
+	OwnerRepository          OwnerType = "repository"
+	OwnerRepositoryContainer OwnerType = "repository_container"
+)
+
+// ComponentMatcher type defines the component scope of the waiver
+type ComponentMatcher string
+
+// Provides guide rails for the matcher strategies
+const (
+	MatchExactComponent ComponentMatcher = "EXACT_COMPONENT"
+	MatchAllComponents  ComponentMatcher = "ALL_COMPONENTS"
+	MatchAllVersions    ComponentMatcher = "ALL_VERSIONS"
+)
+
+type PolicyWaiverProperties struct {
+	Comment              string    `json:"comment,omitempty"`
+	ExpiryTime           time.Time `json:"expiryTime,omitempty"` // time.RFC3339Nano
+	MatcherStrategy      string    `json:"matcherStrategy"`
+	ApplyToAllComponents bool      `json:"applytoAllComponents"`
+}
+
+func CreateWaiverByViolationId(iq IQ, properties PolicyWaiverProperties, ownerType, ownerId string) (err error) {
+	_, err = validateComponentMatcher(properties.MatcherStrategy)
+	if err != nil {
+		return fmt.Errorf("invalid matcher strategy: %v", properties.MatcherStrategy)
+	}
+
+	_, err = validateOwnerType(ownerType)
+	if err != nil {
+		return fmt.Errorf("invalid owner type: %v", ownerType)
+	}
+	request, err := json.Marshal(properties)
+	if err != nil {
+		return fmt.Errorf("could not marshal policy waiver properties: %v", err)
+	}
+
+	endpoint := fmt.Sprintf(policyWaivers, ownerType, ownerId)
+	_, resp, err := iq.Post(endpoint, bytes.NewBuffer(request))
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("did not succeeed in creating waiver: %v", err)
+	}
+	defer resp.Body.Close()
+
+	return
+}
+
+func validateOwnerType(s string) (OwnerType, error) {
+	switch OwnerType(s) {
+	case OwnerApplication, OwnerOrganization, OwnerRepository, OwnerRepositoryContainer:
+		return OwnerType(s), nil
+	default:
+		return "", errors.New("invalid OwnerType value")
+	}
+}
+
+func validateComponentMatcher(s string) (ComponentMatcher, error) {
+	switch ComponentMatcher(s) {
+	case MatchExactComponent, MatchAllComponents, MatchAllVersions:
+		return ComponentMatcher(s), nil
+	default:
+		return "", errors.New("invalid ComponentMatcher value")
+	}
+}

--- a/iq/reports.go
+++ b/iq/reports.go
@@ -89,6 +89,7 @@ type policyReportViolation struct {
 	} `json:"constraints"`
 	Grandfathered        bool   `json:"grandfathered"`
 	PolicyID             string `json:"policyId"`
+	PolicyViolationId    string `json:"policyViolationId"`
 	PolicyName           string `json:"policyName"`
 	PolicyThreatCategory string `json:"policyThreatCategory"`
 	PolicyThreatLevel    int64  `json:"policyThreatLevel"`


### PR DESCRIPTION
As title, simply adds PolicyViolationId to the report violation struct.
This value is returned by the api in the raw json but not yet consumed by the application.

Making this available will allow using the id to post waivers, as part of a later update
 
