### PR TITLE
add policyViolationId to policyReportViolation struct

### DIFF
--- a/iq/reports.go
+++ b/iq/reports.go
@@ -78,7 +78,7 @@ type ReportRaw struct {
 	ReportInfo   ReportInfo            `json:"reportInfo,omitempty"`
 }
 
-type policyReportViolation struct {
+type PolicyReportViolation struct {
 	Constraints []struct {
 		Conditions []struct {
 			ConditionReason  string `json:"conditionReason"`
@@ -99,7 +99,7 @@ type policyReportViolation struct {
 // PolicyReportComponent encapsulates a component which violates a policy
 type PolicyReportComponent struct {
 	Component
-	Violations []policyReportViolation `json:"violations"`
+	Violations []PolicyReportViolation `json:"violations"`
 }
 
 type policyReportCounts struct {

--- a/iq/reports.go
+++ b/iq/reports.go
@@ -89,6 +89,7 @@ type policyReportViolation struct {
 	} `json:"constraints"`
 	Grandfathered        bool   `json:"grandfathered"`
 	PolicyID             string `json:"policyId"`
+	PolicyViolationId    string `json:"policyViolationId"`
 	PolicyName           string `json:"policyName"`
 	PolicyThreatCategory string `json:"policyThreatCategory"`
 	PolicyThreatLevel    int64  `json:"policyThreatLevel"`


### PR DESCRIPTION
As title, adds PolicyViolationId to the report violation struct.
This value is returned by the api in the raw json but not yet consumed by the application.

Making this available will allow using the id to post waivers, as the waiver posting api requires a policyviolationid as an argument

Also, makes policyReportViolation now capitalized so it can be public, allowing for vars of that type to be used when importing to other applications